### PR TITLE
manifest: Track our fork of `system/memory/lmkd` and `system/core`

### DIFF
--- a/snippets/pixel.xml
+++ b/snippets/pixel.xml
@@ -145,13 +145,14 @@
   <!-- System Repos -->
   <project path="system/bpf" name="system_bpf" remote="pixel" />
   <project path="system/bt" name="system_bt" remote="pixelos" />
-  <project path="system/core" name="system_core" remote="pixel" />
+  <project path="system/core" name="system_core" remote="pixelos" />
   <project path="system/extras" name="system_extras" remote="pixelos" />
   <project path="system/incremental_delivery" name="system_incremental_delivery" remote="pixel" />
   <project path="system/libhwbinder" name="system_libhwbinder" remote="pixelos" />
   <project path="system/libufdt" name="system_libufdt" remote="pixel" />
   <project path="system/libziparchive" name="system_libziparchive" remote="pixel" />
   <project path="system/media" name="system_media" remote="pixel" />
+  <project path="system/memory/lmkd" name="system_memory_lmkd" remote="pixelos" />
   <project path="system/netd" name="system_netd" remote="pixelos" />
   <project path="system/nfc" name="system_nfc" remote="pixelos" />
   <project path="system/security" name="system_security" remote="pixelos" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -196,6 +196,7 @@
   <remove-project name="platform/system/libufdt" />
   <remove-project name="platform/system/libziparchive" />
   <remove-project name="platform/system/media" />
+  <remove-project name="platform/system/memory/lmkd" />
   <remove-project name="platform/system/netd" />
   <remove-project name="platform/system/nfc" />
   <remove-project name="platform/system/security" />


### PR DESCRIPTION
- Our fork of system/memory/lmkd is from AOSP Master with one revert.
- Our fork of system/core is from PE with 4 patches for the new ABI of LMKD.

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>