### PR TITLE
manifest: Track webp from upstream

### DIFF
--- a/snippets/external.xml
+++ b/snippets/external.xml
@@ -30,7 +30,6 @@
   <project path="external/mksh" name="LineageOS/android_external_mksh" groups="pdk" remote="LineageOS" />
   <project path="external/setupcompat" name="LineageOS/android_external_setupcompat" groups="pdk" remote="LineageOS" />
   <project path="external/tinycompress" name="LineageOS/android_external_tinycompress" groups="pdk" remote="LineageOS" />
-  <project path="external/webp" name="LineageOS/android_external_webp" groups="pdk,qcom_msm8x26" remote="LineageOS" />
   <project path="external/wpa_supplicant_8" name="LineageOS/android_external_wpa_supplicant_8" groups="pdk" remote="LineageOS" />
   <project path="external/zstd" name="LineageOS/android_external_zstd" groups="pdk" remote="LineageOS" />
 

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -100,7 +100,6 @@
   <remove-project name="platform/external/mksh" />
   <remove-project name="platform/external/setupcompat" />
   <remove-project name="platform/external/tinycompress" />
-  <remove-project name="platform/external/webp" />
   <remove-project name="platform/external/wpa_supplicant_8" />
   <remove-project name="platform/external/zstd" />
 


### PR DESCRIPTION
* Patch "Fix OOB write in BuildHuffmanTable. " has been merged by AOSP.